### PR TITLE
Check if .phpstorm.meta.php is a folder before writing

### DIFF
--- a/src/PimpleDumper.php
+++ b/src/PimpleDumper.php
@@ -304,6 +304,10 @@ class PimpleDumper implements ServiceProviderInterface
     {
         $fileName = $this->_root . DIRECTORY_SEPARATOR . self::FILE_PHPSTORM;
 
+        if (is_dir($fileName)) {
+            $fileName .= DIRECTORY_SEPARATOR . 'pimple.meta.php';
+        }
+
         $list = array();
         foreach ($map as $data) {
             if ($data['type'] === 'class') {

--- a/tests/PimpleDumperTest.php
+++ b/tests/PimpleDumperTest.php
@@ -33,7 +33,13 @@ class PimpleDumperTest extends PHPUnit
 
         $file = PROJECT_ROOT . '/.phpstorm.meta.php';
         if (file_exists($file)) {
-            unlink($file);
+            if (is_dir($file)) {
+                unlink($file . DIRECTORY_SEPARATOR . 'pimple.meta.php');
+                rmdir($file);
+            }
+            else {
+                unlink($file);
+            }
         }
     }
 
@@ -186,6 +192,19 @@ class PimpleDumperTest extends PHPUnit
 
     public function testPhpstorm()
     {
+        $pimple = new Container();
+        $dumper = new PimpleDumper();
+
+        $pimple['f_class'] = function () {
+            return new \stdClass();
+        };
+
+        isFile($dumper->dumpPhpstorm($pimple));
+    }
+
+    public function testPhpstormFile()
+    {
+        mkdir('.phpstorm.meta.php');
         $pimple = new Container();
         $dumper = new PimpleDumper();
 


### PR DESCRIPTION
According to JB documentation .phpstorm.meta.php can be a folder with multiple files. In this case a new should should be created for Pimple map.

@link https://confluence.jetbrains.com/display/PhpStorm/PhpStorm+Advanced+Metadata